### PR TITLE
feat(#4): Add Redemption model with migration

### DIFF
--- a/.claude/plans/004-redeem-reward.md
+++ b/.claude/plans/004-redeem-reward.md
@@ -1,0 +1,180 @@
+# Issue #4: Redeem a Reward
+
+## Overview
+
+Allow users to redeem rewards using their points with pessimistic locking to
+prevent race conditions.
+
+## Commits Plan
+
+**IMPORTANT: Create commits immediately after completing each step below.
+Do NOT wait until all work is done.**
+
+### 1. Add Redemption model with migration
+
+**Files:**
+
+- `api/db/migrate/[timestamp]_create_redemptions.rb`
+- `api/app/models/redemption.rb`
+- `api/app/models/user.rb` (add `has_many :redemptions`)
+- `api/app/models/reward.rb` (add `has_many :redemptions`)
+- `api/test/models/redemption_test.rb`
+- `api/test/fixtures/redemptions.yml`
+
+**Migration:**
+
+```ruby
+create_table :redemptions do |t|
+  t.references :user, null: false, foreign_key: true
+  t.references :reward, null: false, foreign_key: true
+  t.integer :points_spent, null: false
+  t.datetime :redeemed_at, null: false
+  t.timestamps
+end
+add_index :redemptions, [:user_id, :redeemed_at]
+```
+
+---
+
+### 2. Add RedemptionService with pessimistic locking
+
+**Files:**
+
+- `api/app/services/redemption_service.rb`
+- `api/test/services/redemption_service_test.rb`
+
+**Key implementation:**
+
+```ruby
+class RedemptionService
+  class InsufficientPointsError < StandardError; end
+  class RewardUnavailableError < StandardError; end
+
+  def self.redeem(user_id:, reward_id:)
+    new(user_id:, reward_id:).redeem
+  end
+
+  def redeem
+    ActiveRecord::Base.transaction do
+      user = User.lock.find(@user_id)  # Pessimistic lock
+      reward = Reward.find(@reward_id)
+
+      raise RewardUnavailableError unless reward.available
+      raise InsufficientPointsError if user.points_balance < reward.points_cost
+
+      user.update!(points_balance: user.points_balance - reward.points_cost)
+      Redemption.create!(
+        user:, reward:, points_spent: reward.points_cost, redeemed_at: Time.current
+      )
+    end
+  end
+end
+```
+
+**Tests:** Success case, insufficient points, unavailable reward, concurrent
+requests.
+
+---
+
+### 3. Add POST /api/v1/redemptions endpoint
+
+**Files:**
+
+- `api/app/controllers/api/v1/redemptions_controller.rb`
+- `api/app/serializers/redemption_resource.rb`
+- `api/config/routes.rb`
+- `api/test/controllers/api/v1/redemptions_controller_test.rb`
+
+**Request:** `POST /api/v1/redemptions` with `{ "reward_id": 1 }`
+
+**Response:** Redemption JSON with reward nested, or error with appropriate
+status.
+
+---
+
+### 4. Add post method to API client
+
+**Files:**
+
+- `web/src/services/api.ts`
+
+Add `post<T, D>(path, data)` method following the existing `get` pattern.
+
+---
+
+### 5. Add Redemption types and Redux slice
+
+**Files:**
+
+- `web/src/types/redemption.ts`
+- `web/src/store/redemptionSlice.ts`
+- `web/src/store/index.ts`
+
+**Thunk:** `redeemReward(rewardId)` - calls API, then dispatches
+`fetchCurrentUser()` to refresh balance.
+
+---
+
+### 6. Add Modal component
+
+**Files:**
+
+- `web/src/components/ui/Modal.tsx`
+- `web/src/components/ui/Modal.module.css`
+- `web/src/components/ui/Modal.test.tsx`
+
+Reusable modal with: overlay, centered content, ESC to close, click-outside
+to close.
+
+---
+
+### 7. Add RedeemButton component
+
+**Files:**
+
+- `web/src/components/rewards/RedeemButton.tsx`
+- `web/src/components/rewards/RedeemButton.module.css`
+- `web/src/components/rewards/RedeemButton.test.tsx`
+
+Shows: "Redeem" (enabled), "Unavailable" (disabled), "Not Enough Points"
+(disabled).
+
+---
+
+### 8. Add RedemptionConfirmModal component
+
+**Files:**
+
+- `web/src/components/rewards/RedemptionConfirmModal.tsx`
+- `web/src/components/rewards/RedemptionConfirmModal.module.css`
+- `web/src/components/rewards/RedemptionConfirmModal.test.tsx`
+
+Shows: reward name, cost, balance after, error message, Confirm/Cancel
+buttons, loading state.
+
+---
+
+### 9. Integrate RedeemButton and Modal into RewardCard
+
+**Files:**
+
+- `web/src/components/rewards/RewardCard.tsx`
+- `web/src/components/rewards/RewardCard.module.css`
+- `web/src/components/rewards/RewardCard.test.tsx`
+
+Add state for modal visibility, connect to Redux for user points and
+redemption state.
+
+---
+
+## Verification
+
+1. **Backend tests:** `cd api && bin/rails test`
+2. **Frontend tests:** `cd web && bun test`
+3. **Pre-commit hooks:** `pre-commit run --all-files`
+4. **Manual testing:**
+   - Load rewards list, verify RedeemButton appears on each card
+   - Click Redeem on affordable reward, confirm modal opens
+   - Confirm redemption, verify points balance updates
+   - Try redeeming with insufficient points, verify button disabled
+   - Try redeeming unavailable reward, verify button shows "Unavailable"

--- a/api/app/controllers/api/v1/redemptions_controller.rb
+++ b/api/app/controllers/api/v1/redemptions_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    class RedemptionsController < ApplicationController
+      def create
+        raise ArgumentError, "reward_id is required" unless params[:reward_id].present?
+
+        redemption = RedemptionService.redeem(
+          user_id: current_user.id,
+          reward_id: params[:reward_id]
+        )
+        render json: RedemptionResource.new(redemption).serializable_hash, status: :created
+      rescue ArgumentError => e
+        render json: { error: e.message }, status: :bad_request
+      rescue RedemptionService::InsufficientPointsError
+        render json: { error: "Insufficient points" }, status: :unprocessable_entity
+      rescue RedemptionService::RewardUnavailableError
+        render json: { error: "Reward unavailable" }, status: :unprocessable_entity
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "Reward not found" }, status: :not_found
+      end
+    end
+  end
+end

--- a/api/app/models/redemption.rb
+++ b/api/app/models/redemption.rb
@@ -1,0 +1,7 @@
+class Redemption < ApplicationRecord
+  belongs_to :user
+  belongs_to :reward
+
+  validates :points_spent, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :redeemed_at, presence: true
+end

--- a/api/app/models/reward.rb
+++ b/api/app/models/reward.rb
@@ -1,4 +1,6 @@
 class Reward < ApplicationRecord
+  has_many :redemptions
+
   validates :name, presence: true
   validates :points_cost, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :available, inclusion: { in: [ true, false ] }

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :redemptions
+
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :points_balance, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/api/app/serializers/redemption_resource.rb
+++ b/api/app/serializers/redemption_resource.rb
@@ -1,0 +1,7 @@
+class RedemptionResource
+  include Alba::Resource
+
+  attributes :id, :points_spent, :redeemed_at
+
+  one :reward, resource: RewardResource
+end

--- a/api/app/services/redemption_service.rb
+++ b/api/app/services/redemption_service.rb
@@ -1,0 +1,32 @@
+class RedemptionService
+  class InsufficientPointsError < StandardError; end
+  class RewardUnavailableError < StandardError; end
+
+  def self.redeem(user_id:, reward_id:)
+    new(user_id:, reward_id:).redeem
+  end
+
+  def initialize(user_id:, reward_id:)
+    @user_id = user_id
+    @reward_id = reward_id
+  end
+
+  def redeem
+    ActiveRecord::Base.transaction do
+      user = User.lock.find(@user_id)
+      reward = Reward.find(@reward_id)
+
+      raise RewardUnavailableError unless reward.available
+      raise InsufficientPointsError if user.points_balance < reward.points_cost
+
+      user.update!(points_balance: user.points_balance - reward.points_cost)
+
+      Redemption.create!(
+        user:,
+        reward:,
+        points_spent: reward.points_cost,
+        redeemed_at: Time.current
+      )
+    end
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get "users/me", to: "users#me"
       resources :rewards, only: [ :index ]
+      resources :redemptions, only: [ :create ]
     end
   end
 

--- a/api/db/migrate/20260108204345_create_redemptions.rb
+++ b/api/db/migrate/20260108204345_create_redemptions.rb
@@ -1,0 +1,14 @@
+class CreateRedemptions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :redemptions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :reward, null: false, foreign_key: true
+      t.integer :points_spent, null: false
+      t.datetime :redeemed_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :redemptions, [ :user_id, :redeemed_at ]
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_08_180644) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_08_204345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "redemptions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "points_spent", null: false
+    t.datetime "redeemed_at", null: false
+    t.bigint "reward_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["reward_id"], name: "index_redemptions_on_reward_id"
+    t.index ["user_id", "redeemed_at"], name: "index_redemptions_on_user_id_and_redeemed_at"
+    t.index ["user_id"], name: "index_redemptions_on_user_id"
+  end
 
   create_table "rewards", force: :cascade do |t|
     t.boolean "available", default: true, null: false
@@ -32,4 +44,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_08_180644) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
+  add_foreign_key "redemptions", "rewards"
+  add_foreign_key "redemptions", "users"
 end

--- a/api/test/controllers/api/v1/redemptions_controller_test.rb
+++ b/api/test/controllers/api/v1/redemptions_controller_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+module Api
+  module V1
+    class RedemptionsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @user = users(:demo)
+        @reward = rewards(:free_coffee)
+      end
+
+      test "creates redemption with sufficient points" do
+        initial_balance = @user.points_balance
+
+        post api_v1_redemptions_url,
+             params: { reward_id: @reward.id },
+             headers: { "X-User-Id" => @user.id.to_s }
+
+        assert_response :created
+        json = JSON.parse(response.body)
+
+        assert_equal @reward.points_cost, json["points_spent"]
+        assert_not_nil json["redeemed_at"]
+        assert_equal @reward.id, json["reward"]["id"]
+        assert_equal @reward.name, json["reward"]["name"]
+
+        @user.reload
+        assert_equal initial_balance - @reward.points_cost, @user.points_balance
+      end
+
+      test "returns 422 with insufficient points" do
+        @user.update!(points_balance: @reward.points_cost - 1)
+
+        post api_v1_redemptions_url,
+             params: { reward_id: @reward.id },
+             headers: { "X-User-Id" => @user.id.to_s }
+
+        assert_response :unprocessable_entity
+        json = JSON.parse(response.body)
+        assert_equal "Insufficient points", json["error"]
+      end
+
+      test "returns 422 for unavailable reward" do
+        @reward.update!(available: false)
+
+        post api_v1_redemptions_url,
+             params: { reward_id: @reward.id },
+             headers: { "X-User-Id" => @user.id.to_s }
+
+        assert_response :unprocessable_entity
+        json = JSON.parse(response.body)
+        assert_equal "Reward unavailable", json["error"]
+      end
+
+      test "returns 404 for non-existent reward" do
+        post api_v1_redemptions_url,
+             params: { reward_id: -1 },
+             headers: { "X-User-Id" => @user.id.to_s }
+
+        assert_response :not_found
+        json = JSON.parse(response.body)
+        assert_equal "Reward not found", json["error"]
+      end
+
+      test "uses current_user from X-User-Id header" do
+        other_user = User.create!(email: "other@example.com", points_balance: 1000)
+
+        post api_v1_redemptions_url,
+             params: { reward_id: @reward.id },
+             headers: { "X-User-Id" => other_user.id.to_s }
+
+        assert_response :created
+
+        other_user.reload
+        assert_equal 1000 - @reward.points_cost, other_user.points_balance
+      end
+    end
+  end
+end

--- a/api/test/controllers/api/v1/users_controller_test.rb
+++ b/api/test/controllers/api/v1/users_controller_test.rb
@@ -25,6 +25,7 @@ module Api
       end
 
       test "returns 404 when no users exist and no header" do
+        Redemption.delete_all
         User.delete_all
         get api_v1_users_me_url
 

--- a/api/test/fixtures/redemptions.yml
+++ b/api/test/fixtures/redemptions.yml
@@ -1,0 +1,5 @@
+demo_redemption:
+  user: demo
+  reward: free_coffee
+  points_spent: 100
+  redeemed_at: 2026-01-08 12:00:00

--- a/api/test/models/redemption_test.rb
+++ b/api/test/models/redemption_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class RedemptionTest < ActiveSupport::TestCase
+  test "valid redemption" do
+    redemption = Redemption.new(
+      user: users(:demo),
+      reward: rewards(:free_coffee),
+      points_spent: 100,
+      redeemed_at: Time.current
+    )
+    assert redemption.valid?
+  end
+
+  test "requires user" do
+    redemption = Redemption.new(
+      reward: rewards(:free_coffee),
+      points_spent: 100,
+      redeemed_at: Time.current
+    )
+    assert_not redemption.valid?
+    assert_includes redemption.errors[:user], "must exist"
+  end
+
+  test "requires reward" do
+    redemption = Redemption.new(
+      user: users(:demo),
+      points_spent: 100,
+      redeemed_at: Time.current
+    )
+    assert_not redemption.valid?
+    assert_includes redemption.errors[:reward], "must exist"
+  end
+
+  test "requires points_spent" do
+    redemption = Redemption.new(
+      user: users(:demo),
+      reward: rewards(:free_coffee),
+      redeemed_at: Time.current
+    )
+    assert_not redemption.valid?
+    assert_includes redemption.errors[:points_spent], "can't be blank"
+  end
+
+  test "points_spent must be positive" do
+    redemption = Redemption.new(
+      user: users(:demo),
+      reward: rewards(:free_coffee),
+      points_spent: 0,
+      redeemed_at: Time.current
+    )
+    assert_not redemption.valid?
+    assert_includes redemption.errors[:points_spent], "must be greater than 0"
+  end
+
+  test "requires redeemed_at" do
+    redemption = Redemption.new(
+      user: users(:demo),
+      reward: rewards(:free_coffee),
+      points_spent: 100
+    )
+    assert_not redemption.valid?
+    assert_includes redemption.errors[:redeemed_at], "can't be blank"
+  end
+
+  test "belongs to user" do
+    redemption = redemptions(:demo_redemption)
+    assert_equal users(:demo), redemption.user
+  end
+
+  test "belongs to reward" do
+    redemption = redemptions(:demo_redemption)
+    assert_equal rewards(:free_coffee), redemption.reward
+  end
+end

--- a/api/test/services/redemption_service_test.rb
+++ b/api/test/services/redemption_service_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class RedemptionServiceTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:demo)
+    @reward = rewards(:free_coffee)
+  end
+
+  test "successful redemption creates redemption and deducts points" do
+    initial_balance = @user.points_balance
+    points_cost = @reward.points_cost
+
+    redemption = RedemptionService.redeem(user_id: @user.id, reward_id: @reward.id)
+
+    assert_kind_of Redemption, redemption
+    assert_equal @user.id, redemption.user_id
+    assert_equal @reward.id, redemption.reward_id
+    assert_equal points_cost, redemption.points_spent
+    assert_not_nil redemption.redeemed_at
+
+    @user.reload
+    assert_equal initial_balance - points_cost, @user.points_balance
+  end
+
+  test "raises InsufficientPointsError when user has insufficient points" do
+    @user.update!(points_balance: @reward.points_cost - 1)
+
+    assert_raises RedemptionService::InsufficientPointsError do
+      RedemptionService.redeem(user_id: @user.id, reward_id: @reward.id)
+    end
+
+    @user.reload
+    assert_equal @reward.points_cost - 1, @user.points_balance
+    assert_equal 0, Redemption.where(user: @user, reward: @reward).count - 1
+  end
+
+  test "raises RewardUnavailableError when reward is unavailable" do
+    @reward.update!(available: false)
+    initial_balance = @user.points_balance
+
+    assert_raises RedemptionService::RewardUnavailableError do
+      RedemptionService.redeem(user_id: @user.id, reward_id: @reward.id)
+    end
+
+    @user.reload
+    assert_equal initial_balance, @user.points_balance
+  end
+
+  test "raises ActiveRecord::RecordNotFound when user not found" do
+    assert_raises ActiveRecord::RecordNotFound do
+      RedemptionService.redeem(user_id: -1, reward_id: @reward.id)
+    end
+  end
+
+  test "raises ActiveRecord::RecordNotFound when reward not found" do
+    assert_raises ActiveRecord::RecordNotFound do
+      RedemptionService.redeem(user_id: @user.id, reward_id: -1)
+    end
+  end
+
+  test "concurrent requests do not overdraw user balance" do
+    @user.update!(points_balance: @reward.points_cost)
+
+    threads = 2.times.map do
+      Thread.new do
+        RedemptionService.redeem(user_id: @user.id, reward_id: @reward.id)
+      rescue RedemptionService::InsufficientPointsError
+        :insufficient_points
+      end
+    end
+
+    results = threads.map(&:value)
+
+    @user.reload
+    assert @user.points_balance >= 0, "Balance should never go negative"
+
+    redemption_count = results.count { |r| r.is_a?(Redemption) }
+    insufficient_count = results.count { |r| r == :insufficient_points }
+
+    assert_equal 1, redemption_count, "Only one redemption should succeed"
+    assert_equal 1, insufficient_count, "One request should fail with insufficient points"
+    assert_equal 0, @user.points_balance
+  end
+end

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -5,6 +5,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import App from "./App";
 import userReducer from "./store/userSlice";
 import rewardsReducer from "./store/rewardsSlice";
+import redemptionReducer from "./store/redemptionSlice";
 
 vi.mock("./services/api", () => ({
   apiClient: {
@@ -23,12 +24,24 @@ vi.mock("./services/api", () => ({
       }
       return Promise.reject(new Error("Unknown path"));
     }),
+    post: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
   },
 }));
 
 const createTestStore = () =>
   configureStore({
-    reducer: { user: userReducer, rewards: rewardsReducer },
+    reducer: {
+      user: userReducer,
+      rewards: rewardsReducer,
+      redemption: redemptionReducer,
+    },
   });
 
 describe("App", () => {

--- a/web/src/components/rewards/RedeemButton.module.css
+++ b/web/src/components/rewards/RedeemButton.module.css
@@ -1,0 +1,24 @@
+.button {
+  width: 100%;
+  padding: 12px 16px;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  background: #2563eb;
+  color: #fff;
+  transition:
+    background-color 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+  opacity: 0.7;
+}

--- a/web/src/components/rewards/RedeemButton.test.tsx
+++ b/web/src/components/rewards/RedeemButton.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { RedeemButton } from "./RedeemButton";
+import type { Reward } from "../../types/reward";
+
+const mockReward: Reward = {
+  id: 1,
+  name: "Free Coffee",
+  description: "A complimentary coffee",
+  points_cost: 100,
+  image_url: "https://example.com/coffee.jpg",
+  available: true,
+};
+
+describe("RedeemButton", () => {
+  it('shows "Redeem" when user has sufficient points', () => {
+    render(
+      <RedeemButton reward={mockReward} userPoints={500} onClick={vi.fn()} />,
+    );
+    expect(screen.getByTestId("redeem-button")).toHaveTextContent("Redeem");
+    expect(screen.getByTestId("redeem-button")).not.toBeDisabled();
+  });
+
+  it('shows "Not Enough Points" when user has insufficient points', () => {
+    render(
+      <RedeemButton reward={mockReward} userPoints={50} onClick={vi.fn()} />,
+    );
+    expect(screen.getByTestId("redeem-button")).toHaveTextContent(
+      "Not Enough Points",
+    );
+    expect(screen.getByTestId("redeem-button")).toBeDisabled();
+  });
+
+  it('shows "Unavailable" when reward is unavailable', () => {
+    render(
+      <RedeemButton
+        reward={{ ...mockReward, available: false }}
+        userPoints={500}
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("redeem-button")).toHaveTextContent("Unavailable");
+    expect(screen.getByTestId("redeem-button")).toBeDisabled();
+  });
+
+  it("calls onClick when clicked and enabled", () => {
+    const onClick = vi.fn();
+    render(
+      <RedeemButton reward={mockReward} userPoints={500} onClick={onClick} />,
+    );
+
+    fireEvent.click(screen.getByTestId("redeem-button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClick when disabled", () => {
+    const onClick = vi.fn();
+    render(
+      <RedeemButton reward={mockReward} userPoints={50} onClick={onClick} />,
+    );
+
+    fireEvent.click(screen.getByTestId("redeem-button"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    render(
+      <RedeemButton
+        reward={mockReward}
+        userPoints={500}
+        onClick={vi.fn()}
+        disabled={true}
+      />,
+    );
+    expect(screen.getByTestId("redeem-button")).toBeDisabled();
+  });
+
+  it('shows "Unavailable" over "Not Enough Points" when both conditions apply', () => {
+    render(
+      <RedeemButton
+        reward={{ ...mockReward, available: false }}
+        userPoints={50}
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("redeem-button")).toHaveTextContent("Unavailable");
+  });
+});

--- a/web/src/components/rewards/RedeemButton.tsx
+++ b/web/src/components/rewards/RedeemButton.tsx
@@ -1,0 +1,37 @@
+import type { Reward } from "../../types/reward";
+import styles from "./RedeemButton.module.css";
+
+interface RedeemButtonProps {
+  reward: Reward;
+  userPoints: number;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export function RedeemButton({
+  reward,
+  userPoints,
+  onClick,
+  disabled = false,
+}: RedeemButtonProps) {
+  const canAfford = userPoints >= reward.points_cost;
+  const canRedeem = reward.available && canAfford && !disabled;
+
+  let buttonText = "Redeem";
+  if (!reward.available) {
+    buttonText = "Unavailable";
+  } else if (!canAfford) {
+    buttonText = "Not Enough Points";
+  }
+
+  return (
+    <button
+      className={styles.button}
+      onClick={onClick}
+      disabled={!canRedeem}
+      data-testid="redeem-button"
+    >
+      {buttonText}
+    </button>
+  );
+}

--- a/web/src/components/rewards/RedemptionConfirmModal.module.css
+++ b/web/src/components/rewards/RedemptionConfirmModal.module.css
@@ -1,0 +1,89 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.message {
+  margin: 0;
+  font-size: 16px;
+  color: #374151;
+}
+
+.details {
+  background: #f9fafb;
+  border-radius: 6px;
+  padding: 12px 16px;
+}
+
+.detailRow {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+}
+
+.label {
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.value {
+  font-weight: 600;
+  color: #111827;
+  font-size: 14px;
+}
+
+.error {
+  margin: 0;
+  padding: 12px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  color: #b91c1c;
+  font-size: 14px;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.cancelButton,
+.confirmButton {
+  padding: 10px 20px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.cancelButton {
+  background: #fff;
+  border: 1px solid #d1d5db;
+  color: #374151;
+}
+
+.cancelButton:hover:not(:disabled) {
+  background: #f9fafb;
+}
+
+.confirmButton {
+  background: #2563eb;
+  border: none;
+  color: #fff;
+}
+
+.confirmButton:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.cancelButton:disabled,
+.confirmButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/web/src/components/rewards/RedemptionConfirmModal.test.tsx
+++ b/web/src/components/rewards/RedemptionConfirmModal.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { RedemptionConfirmModal } from "./RedemptionConfirmModal";
+import type { Reward } from "../../types/reward";
+
+const mockReward: Reward = {
+  id: 1,
+  name: "Free Coffee",
+  description: "A complimentary coffee",
+  points_cost: 100,
+  image_url: "https://example.com/coffee.jpg",
+  available: true,
+};
+
+describe("RedemptionConfirmModal", () => {
+  const defaultProps = {
+    reward: mockReward,
+    userPoints: 500,
+    isOpen: true,
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+    isRedeeming: false,
+    error: null,
+  };
+
+  it("renders reward name", () => {
+    render(<RedemptionConfirmModal {...defaultProps} />);
+    expect(screen.getByText("Free Coffee")).toBeInTheDocument();
+  });
+
+  it("displays cost", () => {
+    render(<RedemptionConfirmModal {...defaultProps} />);
+    expect(screen.getByTestId("redemption-cost")).toHaveTextContent("100 pts");
+  });
+
+  it("displays balance after redemption", () => {
+    render(<RedemptionConfirmModal {...defaultProps} />);
+    expect(screen.getByTestId("balance-after")).toHaveTextContent("400 pts");
+  });
+
+  it("formats large numbers with locale", () => {
+    render(
+      <RedemptionConfirmModal
+        {...defaultProps}
+        reward={{ ...mockReward, points_cost: 1500 }}
+        userPoints={5000}
+      />,
+    );
+    expect(screen.getByTestId("redemption-cost")).toHaveTextContent("1,500 pts");
+    expect(screen.getByTestId("balance-after")).toHaveTextContent("3,500 pts");
+  });
+
+  it("calls onConfirm when confirm button clicked", () => {
+    const onConfirm = vi.fn();
+    render(<RedemptionConfirmModal {...defaultProps} onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByTestId("confirm-button"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when cancel button clicked", () => {
+    const onClose = vi.fn();
+    render(<RedemptionConfirmModal {...defaultProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("cancel-button"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "Redeeming..." when isRedeeming is true', () => {
+    render(<RedemptionConfirmModal {...defaultProps} isRedeeming={true} />);
+    expect(screen.getByTestId("confirm-button")).toHaveTextContent(
+      "Redeeming...",
+    );
+  });
+
+  it("disables buttons when isRedeeming is true", () => {
+    render(<RedemptionConfirmModal {...defaultProps} isRedeeming={true} />);
+    expect(screen.getByTestId("confirm-button")).toBeDisabled();
+    expect(screen.getByTestId("cancel-button")).toBeDisabled();
+  });
+
+  it("displays error message when error prop is set", () => {
+    render(
+      <RedemptionConfirmModal {...defaultProps} error="Insufficient points" />,
+    );
+    expect(screen.getByTestId("redemption-error")).toHaveTextContent(
+      "Insufficient points",
+    );
+  });
+
+  it("does not display error when error is null", () => {
+    render(<RedemptionConfirmModal {...defaultProps} error={null} />);
+    expect(screen.queryByTestId("redemption-error")).not.toBeInTheDocument();
+  });
+
+  it("does not render when isOpen is false", () => {
+    render(<RedemptionConfirmModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/rewards/RedemptionConfirmModal.tsx
+++ b/web/src/components/rewards/RedemptionConfirmModal.tsx
@@ -1,0 +1,72 @@
+import { Modal } from "../ui/Modal";
+import type { Reward } from "../../types/reward";
+import styles from "./RedemptionConfirmModal.module.css";
+
+interface RedemptionConfirmModalProps {
+  reward: Reward;
+  userPoints: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isRedeeming: boolean;
+  error: string | null;
+}
+
+export function RedemptionConfirmModal({
+  reward,
+  userPoints,
+  isOpen,
+  onClose,
+  onConfirm,
+  isRedeeming,
+  error,
+}: RedemptionConfirmModalProps) {
+  const pointsAfter = userPoints - reward.points_cost;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Confirm Redemption">
+      <div className={styles.content}>
+        <p className={styles.message}>
+          Redeem <strong>{reward.name}</strong>?
+        </p>
+        <div className={styles.details}>
+          <div className={styles.detailRow}>
+            <span className={styles.label}>Cost:</span>
+            <span className={styles.value} data-testid="redemption-cost">
+              {reward.points_cost.toLocaleString()} pts
+            </span>
+          </div>
+          <div className={styles.detailRow}>
+            <span className={styles.label}>Balance after:</span>
+            <span className={styles.value} data-testid="balance-after">
+              {pointsAfter.toLocaleString()} pts
+            </span>
+          </div>
+        </div>
+        {error && (
+          <p className={styles.error} data-testid="redemption-error">
+            {error}
+          </p>
+        )}
+        <div className={styles.actions}>
+          <button
+            className={styles.cancelButton}
+            onClick={onClose}
+            disabled={isRedeeming}
+            data-testid="cancel-button"
+          >
+            Cancel
+          </button>
+          <button
+            className={styles.confirmButton}
+            onClick={onConfirm}
+            disabled={isRedeeming}
+            data-testid="confirm-button"
+          >
+            {isRedeeming ? "Redeeming..." : "Confirm"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/components/rewards/RewardCard.module.css
+++ b/web/src/components/rewards/RewardCard.module.css
@@ -76,4 +76,5 @@
   border-radius: 16px;
   font-size: 14px;
   font-weight: 600;
+  margin-bottom: 12px;
 }

--- a/web/src/components/rewards/RewardCard.test.tsx
+++ b/web/src/components/rewards/RewardCard.test.tsx
@@ -1,7 +1,27 @@
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
 import { RewardCard } from "./RewardCard";
+import userReducer from "../../store/userSlice";
+import rewardsReducer from "../../store/rewardsSlice";
+import redemptionReducer from "../../store/redemptionSlice";
 import type { Reward } from "../../types/reward";
+import type { ReactNode } from "react";
+
+vi.mock("../../services/api", () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
 
 const mockReward: Reward = {
   id: 1,
@@ -12,45 +32,77 @@ const mockReward: Reward = {
   available: true,
 };
 
+const createTestStore = (userPoints: number = 500) =>
+  configureStore({
+    reducer: {
+      user: userReducer,
+      rewards: rewardsReducer,
+      redemption: redemptionReducer,
+    },
+    preloadedState: {
+      user: {
+        user: { id: 1, email: "test@example.com", points_balance: userPoints },
+        loading: false,
+        error: null,
+      },
+      rewards: { rewards: [], loading: false, error: null },
+      redemption: { redeeming: false, error: null, lastRedemption: null },
+    },
+  });
+
+const renderWithProvider = (
+  component: ReactNode,
+  { userPoints = 500 }: { userPoints?: number } = {},
+) => {
+  const store = createTestStore(userPoints);
+  return render(<Provider store={store}>{component}</Provider>);
+};
+
 describe("RewardCard", () => {
   it("renders reward name", () => {
-    render(<RewardCard reward={mockReward} />);
+    renderWithProvider(<RewardCard reward={mockReward} />);
     expect(screen.getByText("Free Coffee")).toBeInTheDocument();
   });
 
   it("renders reward description", () => {
-    render(<RewardCard reward={mockReward} />);
+    renderWithProvider(<RewardCard reward={mockReward} />);
     expect(
       screen.getByText("Enjoy a complimentary coffee of your choice."),
     ).toBeInTheDocument();
   });
 
   it("renders points cost with formatting", () => {
-    render(<RewardCard reward={{ ...mockReward, points_cost: 1500 }} />);
+    renderWithProvider(
+      <RewardCard reward={{ ...mockReward, points_cost: 1500 }} />,
+    );
     expect(screen.getByTestId("points-badge")).toHaveTextContent("1,500 pts");
   });
 
   it("renders image with alt text", () => {
-    render(<RewardCard reward={mockReward} />);
+    renderWithProvider(<RewardCard reward={mockReward} />);
     const image = screen.getByRole("img");
     expect(image).toHaveAttribute("src", mockReward.image_url);
     expect(image).toHaveAttribute("alt", mockReward.name);
   });
 
   it("shows out of stock badge when unavailable", () => {
-    render(<RewardCard reward={{ ...mockReward, available: false }} />);
+    renderWithProvider(
+      <RewardCard reward={{ ...mockReward, available: false }} />,
+    );
     expect(screen.getByTestId("out-of-stock-badge")).toHaveTextContent(
       "Out of Stock",
     );
   });
 
   it("does not show out of stock badge when available", () => {
-    render(<RewardCard reward={mockReward} />);
+    renderWithProvider(<RewardCard reward={mockReward} />);
     expect(screen.queryByTestId("out-of-stock-badge")).not.toBeInTheDocument();
   });
 
   it("handles missing description", () => {
-    render(<RewardCard reward={{ ...mockReward, description: null }} />);
+    renderWithProvider(
+      <RewardCard reward={{ ...mockReward, description: null }} />,
+    );
     expect(screen.getByText("Free Coffee")).toBeInTheDocument();
     expect(
       screen.queryByText("Enjoy a complimentary coffee of your choice."),
@@ -58,7 +110,47 @@ describe("RewardCard", () => {
   });
 
   it("handles missing image", () => {
-    render(<RewardCard reward={{ ...mockReward, image_url: null }} />);
+    renderWithProvider(
+      <RewardCard reward={{ ...mockReward, image_url: null }} />,
+    );
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("renders RedeemButton", () => {
+    renderWithProvider(<RewardCard reward={mockReward} />);
+    expect(screen.getByTestId("redeem-button")).toBeInTheDocument();
+  });
+
+  it('shows "Redeem" button when user has sufficient points', () => {
+    renderWithProvider(<RewardCard reward={mockReward} />, { userPoints: 500 });
+    expect(screen.getByTestId("redeem-button")).toHaveTextContent("Redeem");
+    expect(screen.getByTestId("redeem-button")).not.toBeDisabled();
+  });
+
+  it('shows "Not Enough Points" when user has insufficient points', () => {
+    renderWithProvider(<RewardCard reward={mockReward} />, { userPoints: 50 });
+    expect(screen.getByTestId("redeem-button")).toHaveTextContent(
+      "Not Enough Points",
+    );
+    expect(screen.getByTestId("redeem-button")).toBeDisabled();
+  });
+
+  it("opens modal when redeem button clicked", () => {
+    renderWithProvider(<RewardCard reward={mockReward} />);
+
+    fireEvent.click(screen.getByTestId("redeem-button"));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Confirm Redemption")).toBeInTheDocument();
+  });
+
+  it("closes modal when cancel button clicked", () => {
+    renderWithProvider(<RewardCard reward={mockReward} />);
+
+    fireEvent.click(screen.getByTestId("redeem-button"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("cancel-button"));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/rewards/RewardsList.test.tsx
+++ b/web/src/components/rewards/RewardsList.test.tsx
@@ -4,10 +4,20 @@ import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { RewardsList } from "./RewardsList";
 import rewardsReducer from "../../store/rewardsSlice";
+import userReducer from "../../store/userSlice";
+import redemptionReducer from "../../store/redemptionSlice";
 
 vi.mock("../../services/api", () => ({
   apiClient: {
     get: vi.fn(),
+    post: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
   },
 }));
 
@@ -15,7 +25,19 @@ import { apiClient } from "../../services/api";
 
 const createTestStore = () =>
   configureStore({
-    reducer: { rewards: rewardsReducer },
+    reducer: {
+      rewards: rewardsReducer,
+      user: userReducer,
+      redemption: redemptionReducer,
+    },
+    preloadedState: {
+      user: {
+        user: { id: 1, email: "test@example.com", points_balance: 500 },
+        loading: false,
+        error: null,
+      },
+      redemption: { redeeming: false, error: null, lastRedemption: null },
+    },
   });
 
 const renderWithProvider = () => {

--- a/web/src/components/ui/Modal.module.css
+++ b/web/src/components/ui/Modal.module.css
@@ -1,0 +1,57 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.content {
+  background: #fff;
+  border-radius: 8px;
+  max-width: 400px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+    0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+.content:focus {
+  outline: none;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #6b7280;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.closeButton:hover {
+  color: #111827;
+}
+
+.body {
+  padding: 20px;
+}

--- a/web/src/components/ui/Modal.test.tsx
+++ b/web/src/components/ui/Modal.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Modal } from "./Modal";
+
+describe("Modal", () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    title: "Test Modal",
+    children: <p>Modal content</p>,
+  };
+
+  it("renders when open", () => {
+    render(<Modal {...defaultProps} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Test Modal")).toBeInTheDocument();
+    expect(screen.getByText("Modal content")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(<Modal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when close button clicked", () => {
+    const onClose = vi.fn();
+    render(<Modal {...defaultProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("modal-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when overlay clicked", () => {
+    const onClose = vi.fn();
+    render(<Modal {...defaultProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("modal-overlay"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close when content clicked", () => {
+    const onClose = vi.fn();
+    render(<Modal {...defaultProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("modal-content"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when Escape key pressed", () => {
+    const onClose = vi.fn();
+    render(<Modal {...defaultProps} onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("has proper accessibility attributes", () => {
+    render(<Modal {...defaultProps} />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "modal-title");
+  });
+});

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
+import styles from "./Modal.module.css";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}
+
+export function Modal({ isOpen, onClose, title, children }: ModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const handleEscape = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const handleOverlayClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (event.target === overlayRef.current) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      document.body.style.overflow = "hidden";
+      contentRef.current?.focus();
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, handleEscape]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className={styles.overlay}
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      data-testid="modal-overlay"
+    >
+      <div
+        className={styles.content}
+        ref={contentRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+        tabIndex={-1}
+        data-testid="modal-content"
+      >
+        <div className={styles.header}>
+          <h2 id="modal-title" className={styles.title}>
+            {title}
+          </h2>
+          <button
+            className={styles.closeButton}
+            onClick={onClose}
+            aria-label="Close modal"
+            data-testid="modal-close"
+          >
+            &times;
+          </button>
+        </div>
+        <div className={styles.body}>{children}</div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -28,6 +28,27 @@ export const apiClient = {
 
     return response.json() as Promise<T>;
   },
+
+  async post<T, D = unknown>(path: string, data: D): Promise<T> {
+    const response = await fetch(`${API_BASE_URL}/api/v1${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-User-Id": getUserId(),
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      throw new ApiError(
+        (errorBody as { error?: string }).error || response.statusText,
+        response.status,
+      );
+    }
+
+    return response.json() as Promise<T>;
+  },
 };
 
 export { ApiError };

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -1,11 +1,13 @@
 import { configureStore } from "@reduxjs/toolkit";
 import userReducer from "./userSlice";
 import rewardsReducer from "./rewardsSlice";
+import redemptionReducer from "./redemptionSlice";
 
 export const store = configureStore({
   reducer: {
     user: userReducer,
     rewards: rewardsReducer,
+    redemption: redemptionReducer,
   },
 });
 

--- a/web/src/store/redemptionSlice.ts
+++ b/web/src/store/redemptionSlice.ts
@@ -1,0 +1,62 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { apiClient, ApiError } from "../services/api";
+import { fetchCurrentUser } from "./userSlice";
+import type { Redemption, RedemptionState } from "../types/redemption";
+import type { AppDispatch } from "./index";
+
+const initialState: RedemptionState = {
+  redeeming: false,
+  error: null,
+  lastRedemption: null,
+};
+
+export const redeemReward = createAsyncThunk<
+  Redemption,
+  number,
+  { dispatch: AppDispatch; rejectValue: string }
+>("redemption/redeem", async (rewardId, { dispatch, rejectWithValue }) => {
+  try {
+    const redemption = await apiClient.post<Redemption>("/redemptions", {
+      reward_id: rewardId,
+    });
+    try {
+      await dispatch(fetchCurrentUser());
+    } catch {
+      // Continue even if user fetch fails - redemption succeeded
+    }
+    return redemption;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return rejectWithValue(error.message);
+    }
+    throw error;
+  }
+});
+
+const redemptionSlice = createSlice({
+  name: "redemption",
+  initialState,
+  reducers: {
+    clearRedemptionError: (state) => {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(redeemReward.pending, (state) => {
+        state.redeeming = true;
+        state.error = null;
+      })
+      .addCase(redeemReward.fulfilled, (state, action) => {
+        state.redeeming = false;
+        state.lastRedemption = action.payload;
+      })
+      .addCase(redeemReward.rejected, (state, action) => {
+        state.redeeming = false;
+        state.error = action.payload || "Failed to redeem reward";
+      });
+  },
+});
+
+export const { clearRedemptionError } = redemptionSlice.actions;
+export default redemptionSlice.reducer;

--- a/web/src/types/redemption.ts
+++ b/web/src/types/redemption.ts
@@ -1,0 +1,14 @@
+import type { Reward } from "./reward";
+
+export interface Redemption {
+  id: number;
+  points_spent: number;
+  redeemed_at: string;
+  reward: Reward;
+}
+
+export interface RedemptionState {
+  redeeming: boolean;
+  error: string | null;
+  lastRedemption: Redemption | null;
+}


### PR DESCRIPTION
### TL;DR

Added reward redemption functionality allowing users to spend their points on available rewards.

### What changed?

- Created a `Redemption` model with associations to users and rewards
- Implemented `RedemptionService` with pessimistic locking to prevent race conditions
- Added a POST `/api/v1/redemptions` endpoint to handle redemption requests
- Created UI components for the redemption flow:
  - `RedeemButton` component that shows different states based on availability
  - `Modal` component for confirmation dialogs
  - `RedemptionConfirmModal` to confirm point spending
- Added Redux state management for redemptions with appropriate actions
- Extended the API client with POST capability

### How to test?

1. View the rewards list and verify "Redeem" buttons appear on each card
2. Try redeeming a reward you can afford:
   - Click "Redeem" and confirm in the modal
   - Verify your points balance updates correctly
3. Try redeeming with insufficient points:
   - Button should be disabled with "Not Enough Points" text
4. Try redeeming an unavailable reward:
   - Button should be disabled with "Unavailable" text
5. Run tests:
   - Backend: `cd api && bin/rails test`
   - Frontend: `cd web && bun test`

### Why make this change?

This feature completes the core functionality of the rewards system by allowing users to spend their accumulated points on rewards. The implementation includes safeguards against race conditions through pessimistic locking, ensuring users can't overspend their points even with concurrent redemption attempts.